### PR TITLE
docs: clarify workflow YAML locations and custom additions

### DIFF
--- a/for-developers/writing-tasks/integrating-an-external-command/README.md
+++ b/for-developers/writing-tasks/integrating-an-external-command/README.md
@@ -129,13 +129,15 @@ mytool --include-tags tag1,tag2 --debug --delay 5000 -u TARGET
 ```
 
 {% hint style="warning" %}
-All keys in `opts` must be in lower case, so if you need an upper case option, create :
+All keys in `opts` must be in lowercase. If you need to support an uppercase option, follow these steps :
+
+1. Define the option in opts using a lowercase key:
 ```py
 opts = {
     'my_upper_cas_option':{'type':str, 'shor':'P', 'help': 'Products'}
 }
 ```
-Map your option with 
+2. Map the lowercase key to its corresponding uppercase option using `opt_key_map`:
 ```py
 opt_key_map = {
     'my_upper_cas_option': 'P'

--- a/for-developers/writing-tasks/integrating-an-external-command/README.md
+++ b/for-developers/writing-tasks/integrating-an-external-command/README.md
@@ -287,6 +287,30 @@ mytool \
   -u TARGET
 ```
 
+However, if your tool doesn’t fit into one of `secator`'s built-in command categories, you can define the `meta` options yourself.
+
+For example, let's say we want to support only `HEADER` and `PROXY` options for our tool:
+
+```py
+from secator.definitions import HEADER, METHOD
+from secator.tasks._categories import OPTS
+
+@task()
+class mytool(Command):
+    ...
+    opt_key_map = {
+        # HTTPFuzzer options mapping
+        HEADER: 'H',
+        PROXY: 'x'
+    }
+    meta_opts = {
+        HEADER: OPTS[HEADER],
+        PROXY: OPTS[PROXY],
+    }
+```
+
+With this configuration, you can use your tool with `-method` and `-proxie` options
+
 ***
 
 ### Supporting proxies \[optional]

--- a/for-developers/writing-tasks/integrating-an-external-command/README.md
+++ b/for-developers/writing-tasks/integrating-an-external-command/README.md
@@ -66,6 +66,18 @@ secator x mytool TARGET    # will run mytool -u TARGET
 secator x mytool TXT_FILE  # will run mytool -l TXT_FILE
 ```
 
+#### Important Note on Command Availability
+
+Ensure that the external command you are integrating is callable within your system's `PATH`. For example, a file located at `/opt/tools/testssl.sh/testssl.sh` **will not** work unless properly added to your `PATH`.
+
+To verify if your command is callable, you can run:
+
+```bash
+which [command]
+```
+
+If it returns the path to your command, then it is available and can be used with secator. If not, you will need to update your PATH or move the file to a directory that is already included in your PATH.
+
 ### Parsing a command's output
 
 Now that you have a basic implementation working, you need to convert your command's output into structured output (JSON).
@@ -190,7 +202,7 @@ class mytool(Command, HTTPFuzzer):
         USER_AGENT: 'user-agent',
 
         # my tool specific options
-        'tags': 'include-tags',      
+        'tags': 'include-tags',
     }
     opt_value_map = {
         'delay': lambda x: x * 1000  # convert seconds to milliseconds

--- a/for-developers/writing-tasks/integrating-an-external-command/README.md
+++ b/for-developers/writing-tasks/integrating-an-external-command/README.md
@@ -128,6 +128,21 @@ secator x mytool -t tag1,tag2 -dbg -d 5 TARGET              # short option forma
 mytool --include-tags tag1,tag2 --debug --delay 5000 -u TARGET
 ```
 
+{% hint style="warning" %}
+All keys in `opts` must be in lower case, so if you need an upper case option, create :
+```py
+opts = {
+    'my_upper_cas_option':{'type':str, 'shor':'P', 'help': 'Products'}
+}
+```
+Map your option with 
+```py
+opt_key_map = {
+    'my_upper_cas_option': 'P'
+}
+```
+{% endhint %}
+
 ***
 
 ### Adding an install command \[optional]

--- a/for-developers/writing-workflows.md
+++ b/for-developers/writing-workflows.md
@@ -36,6 +36,30 @@ tasks:
 
 ***
 
+### Finding the Original Workflow Files
+
+The original YAML workflow files provided by secator are located in the installed library directory, typically under:
+
+```
+**/python3.11/site-packages/secator/configs/workflows/*.yaml
+```
+
+To locate these files on your system, you can use the following command:
+
+```bash
+find / -type f -path "*/secator/configs/workflows/*" -name "*.yaml"
+```
+
+This command will search your filesystem for YAML files under the `secator/configs/workflows` path.
+
+### Adding Your Own Workflows
+
+You can add your custom workflows by placing their YAML files in:
+
+* `~/.secator/templates/` (or whatever your `dirs.templates` in [configuration.md](../../../getting-started/configuration.md "mention") points to)
+
+This allows you to extend the functionality of secator without modifying the original library files, making it easier to manage updates and custom configurations.
+
 ## Dynamic targets
 
 You can specify dynamic targets for tasks from current run results, by using the `targets_` key in your template like:


### PR DESCRIPTION
### Description

I wanted to add my own tools to `secator`, but I noticed that the documentation was missing details on two essential points:

1. **Availability of external commands:** It needed clarification that commands must be available in the `PATH` to be executed correctly by `secator`. I added an explanation and a command (`which`) to help users verify command availability.

2. **Location of workflow YAML files:** The documentation didn’t specify where to find existing workflow YAML files. I included their location in the library (`python3.11/site-packages/...`) and added a command to locate them easily. I also explained how and where to add custom workflows (`~/.secator/templates/**`).

### PS

In my opinion, the default workflows should ideally be placed in `~/.secator/templates` instead of remaining in the installed library files. This would make it much easier for users to modify or remove them, as managing them directly within the library is not very practical.

---

**Thank you so much for your work!** Adding tools to `secator` is incredibly cool and straightforward thanks to your approach. 😊
